### PR TITLE
Document the .project file convention in pharo-syntax.md

### DIFF
--- a/.claude/rules/pharo-syntax.md
+++ b/.claude/rules/pharo-syntax.md
@@ -214,6 +214,24 @@ format, causing `NotFound: BaselineOfGoogleCloud` in CI. Locally the explicit
 }
 ```
 
+## Project Root: `.project` File
+
+Every Pharo/Smalltalk repository must have a `.project` file at the repository
+root. This is Iceberg's project descriptor (hardcoded in
+`IceBasicProject>>projectFilePath`), used to resolve `srcDirectory` and other
+project metadata. It is part of the wider Pharo ecosystem convention (used by
+Pharo itself, Seaside, Moose, Tonel, etc.) — not project-specific, so create it
+when scaffolding any new Pharo project:
+
+```
+{
+	'srcDirectory' : 'src'
+}
+```
+
+Set `'srcDirectory'` to match the actual source folder name (`src` for
+Tonel-based layouts, `pharo-repository` for legacy Monticello-package layouts).
+
 ## Metacello Baseline Convention
 
 **CRITICAL:** The baseline package must be named `BaselineOf<ProjectName>`, NOT


### PR DESCRIPTION
## Summary
- Document the `.project` file convention in `.claude/rules/pharo-syntax.md`. Iceberg (Pharo's Git tool) hardcodes `.project` as its project descriptor (`IceBasicProject>>projectFilePath`) to resolve `srcDirectory` and other metadata.
- This repo already has a `.project` file — this PR only adds the rule documentation so future projects scaffolded from this reusable rules file don't miss it.

## Test plan
- [ ] Confirm only `.claude/rules/pharo-syntax.md` changed