### PR TITLE
chore: remove .claude/rules/ reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,4 @@ make test    # run the offline test suite
 make ui      # open the Pharo GUI
 ```
 
-See [docs/development.md](docs/development.md) for the full workflow and
-[`.claude/rules/`](.claude/rules/) for coding conventions.
+See [docs/development.md](docs/development.md) for the full workflow.


### PR DESCRIPTION
## Summary
- Remove `.claude/rules/` reference from README
- This directory is Claude Code-specific configuration and not relevant to general users of the library

## Test plan
- [ ] Verify README markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)